### PR TITLE
Add explicit SASL_MECHANISMS in GMAIL sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ docker run \
   -e POSTFIX_RELAY_HOST='[smtp.gmail.com]:587' \
   -e POSTFIX_RELAY_TLS=may \
   -e POSTFIX_RELAY_AUTH_USER=someone@example.com \
+  -e POSTFIX_RELAY_SASL_MECHANISMS=xoauth2
   -e OAUTH2_TOKEN_AUTO_REFRESH=1 \
   -v SOME-DIRECTORY:/dev-mta-postfix/state \
   moriyoshi/dev-mta-postfix


### PR DESCRIPTION
The usage sample for Gmail XOAUTH2 missed a single line to use SASL mechanism